### PR TITLE
add spread bombs

### DIFF
--- a/buscaminas.py
+++ b/buscaminas.py
@@ -1,8 +1,26 @@
+import random
+
+
 class BuscaMinas:
-    def __init__(self, width=9, height=9):
+    def __init__(self, width=9, height=9, numberOfBombs=10):
         self.width = width
         self.height = height
+        self.numberOfBombs = numberOfBombs
         self.grid = [[Cell(0) for _ in range(width)] for _ in range(height)]
+
+        if (self.width * self.height < numberOfBombs):
+            raise Exception("It is not possible to spread all bombs")
+        
+        while numberOfBombs != 0:
+            rand_x = random.randint(0, height-1)
+            rand_y = random.randint(0, width-1)
+
+            if self.grid[rand_x][rand_y].isBomb():
+                continue
+            else:
+                self.grid[rand_x][rand_y].content = -1
+            
+            numberOfBombs -= 1
     
     def display(self):
         print()
@@ -17,4 +35,7 @@ class Cell:
     def __init__(self, content) -> None:
         self.hidden = True
         self.content = content
+
+    def isBomb(self) -> bool:
+        return self.content == -1
 

--- a/test.py
+++ b/test.py
@@ -17,7 +17,7 @@ class TestBuscaMinas(unittest.TestCase):
             self.assertEqual(len(row), 5)
 
     def test_display_output(self):
-        game = BuscaMinas(2, 2)
+        game = BuscaMinas(2, 2, 1)
         expected_output = "\n. . \n. . \n\n"
 
         original_stdout = sys.stdout  # Save a reference to the original standard output
@@ -25,6 +25,18 @@ class TestBuscaMinas(unittest.TestCase):
         game.display()
         self.assertEqual(sys.stdout.getvalue(), expected_output)
         sys.stdout = original_stdout  # Reset the standard output to its original value
+    
+    def test_bomb_spread(self):
+        numberOfBomb = 0
+        game = BuscaMinas()
+        for row in game.grid:
+            for col in row:
+                if col.isBomb():
+                    numberOfBomb += 1
+        
+        self.assertEqual(game.numberOfBombs, numberOfBomb)
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Motivation

Closes #12 

## Summary of changes

At the begining of each game the bombs are spread all over the grid

## Checklist
- [X] Tested the changes locally.
- [ ] Reviewed the changes on GitHub, line by line.
- [X] Unit tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
